### PR TITLE
feat: Add dynamic data badges views

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ Put whatever text you want in this static badge, which is independent of a repo.
 
 </div>
 
+### Dynamic
+
+Creates a badge based on a label, query, and a JSON file uploaded. 
+
+<div align="center">
+
+![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
+
+</div>
+
+
 ### Packages
 
 An NPM package badge that changes magically when your `package.json` file is updated.

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Put whatever text you want in this static badge, which is independent of a repo.
 
 ### Dynamic data
 
-Create a badge that references any value you want in a given JSON file and it will always stay up to date. Badge inputs are the text label, the JSON query, and URL for a JSON file (e.g. a `package.json` file on a GitHub repo or a JSON file on your REST API server).
+Create a badge that references any value you want in a given remote JSON file and it will always stay up to date.
 
 In the example below, we look-up the required VS Code version for a VS Code extension by using the `$.engines["vscode"]` query against this [package.json](https://github.com/MichaelCurrin/auto-commit-msg/blob/master/package.json) file on a GitHub repo.
 
 <div align="center">
 
-![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
+![VS Code](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Put whatever text you want in this static badge, which is independent of a repo.
 
 </div>
 
-### Dynamic
+### Dynamic data
 
-Creates a badge based on a label, query, and a JSON file uploaded. 
+Create a badge that references any value you want in a given JSON file and it will always stay up to date. Badge inputs are the text label, the JSON query, and URL for a JSON file (e.g. a `package.json` file on a GitHub repo or a JSON file on your REST API server).
+
+In the example below, we look-up the required VS Code version for a VS Code extension by using the `$.engines["vscode"]` query against this [package.json](https://github.com/MichaelCurrin/auto-commit-msg/blob/master/package.json) file on a GitHub repo.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ In the example below, we look-up the required VS Code version for a VS Code exte
 
 <div align="center">
 
-![VS Code](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
+![VS Code](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ In the example below, we look-up the required VS Code version for a VS Code exte
 
 <div align="center">
 
-![VS Code](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
+![auto-commit-msg](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.engines%5B%22vscode%22%5D&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)
+)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Put whatever text you want in this static badge, which is independent of a repo.
 
 ### Dynamic data
 
-Create a badge that references any value you want in a given remote JSON file and it will always stay up to date.
+Create a badge that references any value within a public data file (currently only JSON supported). It will always stay up to date.
 
 In the example below, we look-up the required VS Code version for a VS Code extension by using the `$.engines["vscode"]` query against this [package.json](https://github.com/MichaelCurrin/auto-commit-msg/blob/master/package.json) file on a GitHub repo.
 

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -3,6 +3,7 @@ const SHIELDS_API_BASE = "https://img.shields.io";
 export const SHIELDS_API = {
   DASH: `${SHIELDS_API_BASE}/badge`,
   PARAM: `${SHIELDS_API_BASE}/static/v1`,
+  DYNAMIC_JSON: `${SHIELDS_API_BASE}/badge/dynamic/json`,
   GH: `${SHIELDS_API_BASE}/github`,
   PKG_JSON_DEPENDENCY: `${SHIELDS_API_BASE}/github/package-json/dependency-version`,
   GO_MODULE: `${SHIELDS_API_BASE}/github/go-mod/go-version`,

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -1,71 +1,37 @@
-import { dynamicBadge } from "@/core/dynamicData";
+import { mdImageWithLink } from "./markdown";
+import { dynamicParamsUrl } from "./shieldsApi";
 
-describe("Dynamic data badges", () => {
-  describe("#dynamicBadge", () => {
-    describe("required input handling", () => {
-      const label = "version"
-      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
-      const query = "$.version"
+/**
+ * Dynamic data badge.
+ *
+ * Generate a live-updating badge that references a value in a data file.
+ * Only JSON is supported.
+ */
+export function dynamicBadge(
+  label: string,
+  url: string,
+  query: string,
+  linkTarget = "",
+  altText = ""
+) {
+  if (!label) {
+    throw new Error("`label` may not be empty");
+  }
+  if (!url) {
+    throw new Error("`url` may not be empty");
+  }
+  if (!query) {
+    throw new Error("`query` may not be empty");
+  }
+  if (!altText) {
+    altText = label;
+  }
 
-      it("displays a badge correctly when label, URL, query are set", () => {
-        const expected = "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
-        
-        expect(dynamicBadge(label,url,query)).toBe(
-          expected
-        );
-      });
+  const imageTarget = dynamicParamsUrl({ label, url, query });
 
-      describe("validate missing inputs", () => {
-        it("throws an error when `label` is not set", () => {
-          expect(() =>
-            dynamicBadge("", url,  query)
-          ).toThrow();
-
-          expect(() =>
-            dynamicBadge(undefined, url,  query)
-          ).toThrow();
-
-          expect(() =>
-            dynamicBadge(null, url,  query)
-          ).toThrow();
-        });
-  
-        it("throws an error when `url` is not set", () => {
-          expect(() => dynamicBadge(label, "", query)).toThrow();
-        });
-  
-        it("throws an error when `query` is not set", () => {
-          expect(() =>
-            dynamicBadge(
-              label,
-              url,
-              ""
-            )
-          ).toThrow();
-        });
-      });
-    });
-
-    describe("optional input handling", () => {
-      const label = "version"
-      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
-      const query = "$.version"
-      
-      it("displays a badge pointing to an external link when a link is given", () => {
-        const linkTarget = "https://example.com";
-        const expected = "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
-        
-        expect(
-          dynamicBadge(
-            label,
-            url,
-            query,
-            linkTarget
-          )
-        ).toBe(
-          expected
-        );
-      });
-    });
+  return mdImageWithLink({
+    altText,
+    imageTarget,
+    linkTarget,
   });
-});
+}

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -4,7 +4,7 @@ import { dynamicParamsUrl } from "./shieldsApi";
 /**
  * Dynamic data badge.
  *
- * Generate a live-updating badge that references a value in a config file.
+ * Generate a live-updating badge that references a value in a data file.
  * Only JSON is supported.
  */
 export function dynamicBadge(

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -1,10 +1,11 @@
-import { mdImage, mdImageWithLink } from "./markdown";
+import { mdImageWithLink } from "./markdown";
 import { dynamicParamsUrl } from "./shieldsApi";
 
 /**
  * Dynamic data badge.
  *
- * Generate a live-updating badge that references a value in a config - currently only JSON supported.
+ * Generate a live-updating badge that references a value in a config -
+ * currently only JSON supported.
  */
 export function dynamicBadge(
   label: string,

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -24,7 +24,7 @@ export function dynamicBadge(
     throw new Error("`query` may not be empty");
   }
   if (!altText) {
-    altText = label
+    altText = label;
   }
 
   const imageTarget = dynamicParamsUrl({ label, url, query });

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -1,37 +1,71 @@
-import { mdImageWithLink } from "./markdown";
-import { dynamicParamsUrl } from "./shieldsApi";
+import { dynamicBadge } from "@/core/dynamicData";
 
-/**
- * Dynamic data badge.
- *
- * Generate a live-updating badge that references a value in a data file.
- * Only JSON is supported.
- */
-export function dynamicBadge(
-  label: string,
-  url: string,
-  query: string,
-  linkTarget = "",
-  altText = ""
-) {
-  if (!label) {
-    throw new Error("`label` may not be empty");
-  }
-  if (!url) {
-    throw new Error("`url` may not be empty");
-  }
-  if (!query) {
-    throw new Error("`query` may not be empty");
-  }
-  if (!altText) {
-    altText = label;
-  }
+describe("Dynamic data badges", () => {
+  describe("#dynamicBadge", () => {
+    describe("required input handling", () => {
+      const label = "version"
+      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
+      const query = "$.version"
 
-  const imageTarget = dynamicParamsUrl({ label, url, query });
+      it("displays a badge correctly when label, URL, query are set", () => {
+        const expected = "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
+        
+        expect(dynamicBadge(label,url,query)).toBe(
+          expected
+        );
+      });
 
-  return mdImageWithLink({
-    altText,
-    imageTarget,
-    linkTarget,
+      describe("validate missing inputs", () => {
+        it("throws an error when `label` is not set", () => {
+          expect(() =>
+            dynamicBadge("", url,  query)
+          ).toThrow();
+
+          expect(() =>
+            dynamicBadge(undefined, url,  query)
+          ).toThrow();
+
+          expect(() =>
+            dynamicBadge(null, url,  query)
+          ).toThrow();
+        });
+  
+        it("throws an error when `url` is not set", () => {
+          expect(() => dynamicBadge(label, "", query)).toThrow();
+        });
+  
+        it("throws an error when `query` is not set", () => {
+          expect(() =>
+            dynamicBadge(
+              label,
+              url,
+              ""
+            )
+          ).toThrow();
+        });
+      });
+    });
+
+    describe("optional input handling", () => {
+      const label = "version"
+      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
+      const query = "$.version"
+      
+      it("displays a badge pointing to an external link when a link is given", () => {
+        const linkTarget = "https://example.com";
+        const expected = "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
+        
+        expect(
+          dynamicBadge(
+            label,
+            url,
+            query,
+            linkTarget
+          )
+        ).toBe(
+          expected
+        );
+      });
+    });
   });
-}
+});

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -1,0 +1,32 @@
+import { mdImage, mdImageWithLink } from "./markdown";
+import { dynamicParamsUrl } from "./shieldsApi";
+
+export function dynamicBadge(
+  label: string,
+  url: string,
+  query: string,
+  linkTarget = "",
+  altText = ""
+) {
+  if (!label) {
+    throw new Error("`label` may not be empty");
+  }
+
+  if (!url) {
+    throw new Error("`url` may not be empty");
+  }
+
+  if (!query) {
+    throw new Error("`query` may not be empty");
+  }
+
+  const badgeFields = { label, url, query };
+
+  const imageTarget = dynamicParamsUrl(badgeFields);
+
+  return mdImageWithLink({
+    altText,
+    imageTarget,
+    linkTarget,
+  });
+}

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -17,17 +17,17 @@ export function dynamicBadge(
   if (!label) {
     throw new Error("`label` may not be empty");
   }
-
   if (!url) {
     throw new Error("`url` may not be empty");
   }
-
   if (!query) {
     throw new Error("`query` may not be empty");
   }
+  if (!altText) {
+    altText = label
+  }
 
-  const badgeFields = { label, url, query };
-  const imageTarget = dynamicParamsUrl(badgeFields);
+  const imageTarget = dynamicParamsUrl({ label, url, query });
 
   return mdImageWithLink({
     altText,

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -4,8 +4,8 @@ import { dynamicParamsUrl } from "./shieldsApi";
 /**
  * Dynamic data badge.
  *
- * Generate a live-updating badge that references a value in a config -
- * currently only JSON supported.
+ * Generate a live-updating badge that references a value in a config file.
+ * Only JSON is supported.
  */
 export function dynamicBadge(
   label: string,

--- a/src/core/dynamicData.ts
+++ b/src/core/dynamicData.ts
@@ -1,6 +1,11 @@
 import { mdImage, mdImageWithLink } from "./markdown";
 import { dynamicParamsUrl } from "./shieldsApi";
 
+/**
+ * Dynamic data badge.
+ *
+ * Generate a live-updating badge that references a value in a config - currently only JSON supported.
+ */
 export function dynamicBadge(
   label: string,
   url: string,
@@ -21,7 +26,6 @@ export function dynamicBadge(
   }
 
   const badgeFields = { label, url, query };
-
   const imageTarget = dynamicParamsUrl(badgeFields);
 
   return mdImageWithLink({

--- a/src/core/shieldsApi.ts
+++ b/src/core/shieldsApi.ts
@@ -2,7 +2,6 @@
  * Shields.io API module.
  */
 import { COLOR_PRESETS, STYLES } from "@/constants/appearance";
-import { BADGE_DEFAULTS } from "@/constants/catalogue";
 import { SHIELDS_API } from "@/constants/urls";
 import { buildUrl } from "./badges";
 import { TLogoAppearance } from "./shieldsApi.d";

--- a/src/core/shieldsApi.ts
+++ b/src/core/shieldsApi.ts
@@ -2,10 +2,17 @@
  * Shields.io API module.
  */
 import { COLOR_PRESETS, STYLES } from "@/constants/appearance";
+import { BADGE_DEFAULTS } from "@/constants/catalogue";
 import { SHIELDS_API } from "@/constants/urls";
 import { buildUrl } from "./badges";
 import { TLogoAppearance } from "./shieldsApi.d";
-import { GenericBadge, GHRepo, RepoMetric, StrMap } from "./types.d";
+import {
+  GenericBadge,
+  DynamicBadge,
+  GHRepo,
+  RepoMetric,
+  StrMap,
+} from "./types.d";
 
 // Enums don't seem to work in `.d` files, so here is best now.
 export enum ENVIRONMENT {
@@ -113,6 +120,19 @@ export function staticParamsUrl(badge: GenericBadge, styleParams: StrMap) {
   };
 
   return buildUrl(SHIELDS_API.PARAM, params);
+}
+
+/**
+ * Image URL for param-based dynamic badge using json as source.
+ */
+export function dynamicParamsUrl(badge: DynamicBadge) {
+  const params = {
+    label: badge.label,
+    query: badge.query,
+    url: badge.url,
+  };
+
+  return buildUrl(SHIELDS_API.DYNAMIC_JSON, params);
 }
 
 /**

--- a/src/core/shieldsApi.ts
+++ b/src/core/shieldsApi.ts
@@ -129,7 +129,7 @@ export function staticParamsUrl(badge: GenericBadge, styleParams: StrMap) {
 export function dynamicParamsUrl(badge: DynamicBadge) {
   const params = {
     label: badge.label,
-    query: badge.query,
+    query: _encodeParam(badge.query), // encode the query separately, because it gets decoded by buildUrl
     url: badge.url,
   };
 

--- a/src/core/shieldsApi.ts
+++ b/src/core/shieldsApi.ts
@@ -123,7 +123,9 @@ export function staticParamsUrl(badge: GenericBadge, styleParams: StrMap) {
 }
 
 /**
- * Image URL for param-based dynamic badge using json as source.
+ * Return the image URL for a param-based dynamic data badge.
+ *
+ * Only JSON config file are supported here.
  */
 export function dynamicParamsUrl(badge: DynamicBadge) {
   const params = {

--- a/src/core/types.d.ts
+++ b/src/core/types.d.ts
@@ -8,6 +8,12 @@ export type GenericBadge = {
   color: string;
 };
 
+export type DynamicBadge = {
+  label: string;
+  url: string;
+  query: string;
+};
+
 // Simpler than Repo class and useful for functions used within Repo class
 // methods where Repo type can't be used. Plus, if you pass Repo type to a
 // function expecting GHRepo, it still works.

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,12 @@ export const routes: Array<RouteRecordRaw> = [
       import(/* webpackChunkName: "generic" */ "@/views/GenericBadges.vue"),
   },
   {
+    path: "/dynamic",
+    name: "Dynamic",
+    component: () =>
+      import(/* webpackChunkName: "generic" */ "@/views/DynamicBadges.vue"),
+  },
+  {
     path: "/package",
     name: "Package",
     component: () =>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,7 +24,7 @@ export const routes: Array<RouteRecordRaw> = [
     path: "/dynamic",
     name: "Dynamic",
     component: () =>
-      import(/* webpackChunkName: "generic" */ "@/views/DynamicBadges.vue"),
+      import(/* webpackChunkName: "dynamicData" */ "@/views/DynamicBadges.vue"),
   },
   {
     path: "/package",

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -93,7 +93,7 @@ import TextInput from "@/components/TextInput.vue";
 import { dynamicBadge } from "@/core/dynamicData";
 
 const note = `
-Reference a value in remote JSON file and the badge will update as the content changes.
+Reference a value in remote data file and the badge will update as the content changes. Only JSON files are supported in this generator.
 
 Help on form fields:
 

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -69,9 +69,9 @@ import TextInput from "@/components/TextInput.vue";
 import { dynamicBadge } from "@/core/dynamicData";
 
 const note = `
-This form lets you create a dynamic badge by passing a URL to a JSON file and a [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) to the value.
+This form lets you create a dynamic data badge so you can get any value you want out of a public JSON file. For understanding the `query` syntax, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html).
 
-For example, describe tools or platforms your repo is built on or built for running.
+For example, for a `package.json` file of an NPM package on GitHub, get the `keywords` field or the supported version of Node listed inside the `engines`. Or look-up a value published on your REST API server that indicates its uptime, queue size, last deploy date, etc.
 `;
 
 export default defineComponent({

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -14,15 +14,39 @@
           <form @submit.prevent.enter="submit">
             <fieldset name="text">
               <legend>Text</legend>
-
-              <TextInput label="Label" v-model="label" isRequired />
+              <TextInput
+                label="Alt text"
+                v-model="altText"
+                placeholder="e.g. Keywords"
+                note="Markdown fallback text. If omitted, _Label_ will be used."
+              />
               <br />
 
-              <TextInput label="URL" v-model="url" isRequired />
+              <TextInput
+                label="Label"
+                v-model="label"
+                isRequired
+                placeholder="e.g. keywords"
+                note="Display text for the left of the badge"
+              />
               <br />
 
-              <TextInput label="Query" v-model="query" isRequired />
+              <TextInput
+                label="URL"
+                v-model="url"
+                isRequired
+                placeholder="e.g. https://example.com/foo.json"
+                note="URL for a public JSON file."
+              />
               <br />
+
+              <TextInput
+                label="Query"
+                v-model="query"
+                isRequired
+                placeholder="e.g. $.keywords "
+                note="JSON value query."
+              />
             </fieldset>
             <br />
 
@@ -71,17 +95,23 @@ import { dynamicBadge } from "@/core/dynamicData";
 const note = `
 Reference a value in remote JSON file and the badge will update as the content changes.
 
-Help on fields:
+Help on form fields:
 
-- Label: A text label to display.
-    - e.g. \`keywords\`
-    - e.g.  \`vscode\` or \`VS Code\`
-- URL: A raw URL for a JSON file on GitHub, or URL for a JSON file on your REST API server.
-    - e.g. \`https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json\`
-    - e.g. \`https://example.com/foo.json\`
-- Query: Look-up value within the data structure. For syntax rules, see this [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) guide.
-    - e.g. \`$.keywords\`
-    - e.g. \`$.engines["vscode"]\`
+- Label: A text label to display. e.g.
+    - \`keywords\`
+    - \`vscode\` or \`VS Code\`
+- URL: A raw URL for a JSON file on GitHub, or URL for a JSON file on your REST API server. e.g.
+    - \`https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json\`
+    - \`https://example.com/foo.json\`
+- Query: Look-up value within the data structure. For syntax rules, see this [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) guide.  e.g.
+    - \`$.keywords\`
+    - \`$.engines["vscode"]\`
+
+Sample badges:
+
+- Badge Generator package.json - [![node](https://img.shields.io/badge/dynamic/json?label=node&query=%24.engines["node"]&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fbadge-generator%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/badge-generator)
+-  AutoCommitMsg package.json - [![keywords](https://img.shields.io/badge/dynamic/json?label=keywords&query=%24.keywords&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/auto-commit-msg)
+- AutoCommitMsg package.json - [![vscode](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.engines["vscode"]&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/auto-commit-msg/)
 `;
 
 export default defineComponent({
@@ -93,12 +123,13 @@ export default defineComponent({
   },
   data() {
     return {
+      altText: "",
       label: "",
       url: "",
       query: "",
       target: "",
       result: INITIAL_RESULT,
-      note: note,
+      note,
     };
   },
   methods: {

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -2,7 +2,7 @@
   <div class="badges container-lg">
     <div class="row">
       <div class="col-12">
-        <h1>Dynamic badges</h1>
+        <h1>Dynamic data badges</h1>
       </div>
     </div>
 
@@ -69,14 +69,19 @@ import TextInput from "@/components/TextInput.vue";
 import { dynamicBadge } from "@/core/dynamicData";
 
 const note = `
-This form lets you create a dynamic data badge so you can get any value you want
-out of a public JSON file. For understanding the \`query\` syntax,
-see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html).
+References a value in remote JSON file and it will update dynamically.
 
-For example, for a \`package.json\` file of an NPM package on GitHub, get the
-\`keywords\` field or the supported version of Node listed inside the
-\`engines\`. Or look-up a value published on your REST API server that
-indicates its uptime, queue size, last deploy date, etc.
+Help on fields:
+
+- Label: A text label to display .
+    - e.g. \`Keywords\`
+    - e.g. \`VS Code\`.
+- Query: Look-up value within the data structure. For syntax rules, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html)
+    - e.g. \`$.keywords\`
+    - e.g. \`$.engines["vscode"]\`
+- URL: A raw URL for JSON file on GitHub. Or URL for a JSON file on your REST API server.
+    - e.g. \`https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json\`
+    - e.g. \`https://example.com/foo.json\`
 `;
 
 export default defineComponent({

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -69,17 +69,17 @@ import TextInput from "@/components/TextInput.vue";
 import { dynamicBadge } from "@/core/dynamicData";
 
 const note = `
-References a value in remote JSON file and it will update dynamically.
+Reference a value in remote JSON file and the badge will update as the content changes.
 
 Help on fields:
 
-- Label: A text label to display .
-    - e.g. \`Keywords\`
-    - e.g. \`VS Code\`.
-- URL: A raw URL for JSON file on GitHub. Or URL for a JSON file on your REST API server.
+- Label: A text label to display.
+    - e.g. \`keywords\`
+    - e.g.  \`vscode\` or \`VS Code\`
+- URL: A raw URL for a JSON file on GitHub, or URL for a JSON file on your REST API server.
     - e.g. \`https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json\`
     - e.g. \`https://example.com/foo.json\`
-- Query: Look-up value within the data structure. For syntax rules, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html)
+- Query: Look-up value within the data structure. For syntax rules, see this [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) guide.
     - e.g. \`$.keywords\`
     - e.g. \`$.engines["vscode"]\`
 `;

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -134,10 +134,6 @@ export default defineComponent({
   },
   methods: {
     submit() {
-      console.debug("Process inputs and render results");
-
-      const args = [this.label, this.url, this.query];
-      console.debug(args);
 
       const paramBadge = dynamicBadge(
         this.label,

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -110,7 +110,7 @@ Help on form fields:
 Sample badges:
 
 - Badge Generator package.json - [![node](https://img.shields.io/badge/dynamic/json?label=node&query=%24.engines["node"]&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fbadge-generator%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/badge-generator)
--  AutoCommitMsg package.json - [![keywords](https://img.shields.io/badge/dynamic/json?label=keywords&query=%24.keywords&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/auto-commit-msg)
+- AutoCommitMsg package.json - [![keywords](https://img.shields.io/badge/dynamic/json?label=keywords&query=%24.keywords&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/auto-commit-msg)
 - AutoCommitMsg package.json - [![vscode](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.engines["vscode"]&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://github.com/MichaelCurrin/auto-commit-msg/)
 `;
 

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="badges container-lg">
+    <div class="row">
+      <div class="col-12">
+        <h1>Dynamic badges</h1>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-6">
+        <div class="app-input">
+          <h2>Input values</h2>
+
+          <form @submit.prevent.enter="submit">
+            <fieldset name="text">
+              <legend>Text</legend>
+
+              <TextInput label="Label" v-model="label" isRequired />
+              <br />
+
+              <TextInput label="URL" v-model="url" isRequired />
+              <br />
+
+              <TextInput label="Query" v-model="query" isRequired />
+              <br />
+            </fieldset>
+            <br />
+
+            <fieldset name="links">
+              <legend>Links</legend>
+
+              <TextInput
+                label="Click target"
+                v-model="target"
+                placeholder="e.g. https://example.com"
+                note="URL or a local path like `/docs/`. This doesn't have to be set, but a button without a click destination is not so useful."
+              />
+            </fieldset>
+
+            <br />
+
+            <input class="btn" type="submit" value="Submit" />
+          </form>
+        </div>
+      </div>
+
+      <div class="col-6">
+        <Results :result="result" />
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-12">
+        <Help :message="note" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import { INITIAL_RESULT } from "@/constants/text";
+
+import Help from "@/components/Help.vue";
+import Results from "@/components/Results.vue";
+import TextInput from "@/components/TextInput.vue";
+
+import { dynamicBadge } from "@/core/dynamicData";
+
+const note = `
+This form lets you create a dynamic badge by passing a URL to a JSON file and a [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) to the value.
+
+For example, describe tools or platforms your repo is built on or built for running.
+`;
+
+export default defineComponent({
+  name: "DynamicBadges",
+  components: {
+    Help,
+    Results,
+    TextInput,
+  },
+  data() {
+    return {
+      label: "Foo",
+      url: "",
+      query: "",
+      target: "",
+      result: INITIAL_RESULT,
+      note: note,
+    };
+  },
+  methods: {
+    submit() {
+      console.debug("Process inputs and render results");
+
+      const args = [this.label, this.url, this.query];
+      console.debug(args);
+
+      const paramBadge = dynamicBadge(
+        this.label,
+        this.url,
+        this.query,
+        this.target
+      );
+
+      this.result = `\
+_Query parameter badge_
+
+${paramBadge}
+      `;
+    },
+  },
+});
+</script>

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -69,9 +69,14 @@ import TextInput from "@/components/TextInput.vue";
 import { dynamicBadge } from "@/core/dynamicData";
 
 const note = `
-This form lets you create a dynamic data badge so you can get any value you want out of a public JSON file. For understanding the `query` syntax, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html).
+This form lets you create a dynamic data badge so you can get any value you want
+out of a public JSON file. For understanding the \`query\` syntax,
+see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html).
 
-For example, for a `package.json` file of an NPM package on GitHub, get the `keywords` field or the supported version of Node listed inside the `engines`. Or look-up a value published on your REST API server that indicates its uptime, queue size, last deploy date, etc.
+For example, for a \`package.json\` file of an NPM package on GitHub, get the
+\`keywords\` field or the supported version of Node listed inside the
+\`engines\`. Or look-up a value published on your REST API server that
+indicates its uptime, queue size, last deploy date, etc.
 `;
 
 export default defineComponent({

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -76,12 +76,12 @@ Help on fields:
 - Label: A text label to display .
     - e.g. \`Keywords\`
     - e.g. \`VS Code\`.
-- Query: Look-up value within the data structure. For syntax rules, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html)
-    - e.g. \`$.keywords\`
-    - e.g. \`$.engines["vscode"]\`
 - URL: A raw URL for JSON file on GitHub. Or URL for a JSON file on your REST API server.
     - e.g. \`https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json\`
     - e.g. \`https://example.com/foo.json\`
+- Query: Look-up value within the data structure. For syntax rules, see [JSON path](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html)
+    - e.g. \`$.keywords\`
+    - e.g. \`$.engines["vscode"]\`
 `;
 
 export default defineComponent({
@@ -93,7 +93,7 @@ export default defineComponent({
   },
   data() {
     return {
-      label: "Foo",
+      label: "",
       url: "",
       query: "",
       target: "",

--- a/src/views/DynamicBadges.vue
+++ b/src/views/DynamicBadges.vue
@@ -134,7 +134,6 @@ export default defineComponent({
   },
   methods: {
     submit() {
-
       const paramBadge = dynamicBadge(
         this.label,
         this.url,

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -1,56 +1,62 @@
 import { dynamicBadge } from "@/core/dynamicData";
 
-describe("#dynamicBadge", () => {
-  describe("Url, label, and query", () => {
-    it("displays a badge with a given label, URL and query", () => {
-      expect(
-        dynamicBadge(
-          "version",
-          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-          "version"
-        )
-      ).toBe(
-        "![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
-      );
-    });
+describe("Dynamic data badges", () => {
+  describe("#dynamicBadge", () => {
+    describe("required inputs set", () => {
+      it("displays a badge correctly when label, URL, query are set", () => {
+        expect(
+          dynamicBadge(
+            "version",
+            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+            "$.version"
+          )
+        ).toBe(
+          "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
+        );
+      });
 
-    it("throws an error if `label` is empty", () => {
-      expect(() =>
-        dynamicBadge(
-          "",
-          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-          "version"
-        )
-      ).toThrow();
-    });
+      describe("optional inputs are set", () => {
+        it("displays a badge pointing to an external link", () => {
+          const linkTarget = "https://example.com";
 
-    it("throws an error if `url` is empty", () => {
-      expect(() => dynamicBadge("version", "", "version")).toThrow();
-    });
+          expect(
+            dynamicBadge(
+              "version",
+              "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+              "$.version",
+              linkTarget
+            )
+          ).toBe(
+            "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
+          );
+        })
+      })
+    })
 
-    it("throws an error if `query` is empty", () => {
-      expect(() =>
-        dynamicBadge(
-          "version",
-          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-          ""
-        )
-      ).toThrow();
-    });
+    describe("validate when required inputs are not set", () => {
+      it("throws an error if `label` is empty", () => {
+        expect(() =>
+          dynamicBadge(
+            "",
+            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+            "version"
+          )
+        ).toThrow();
+      });
 
-    it("displays a badge pointing to an external link", () => {
-      const linkTarget = "https://example.com";
+      it("throws an error if `url` is empty", () => {
+        expect(() => dynamicBadge("version", "", "version")).toThrow();
+      });
 
-      expect(
-        dynamicBadge(
-          "version",
-          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-          "version",
-          linkTarget
-        )
-      ).toBe(
-        "[![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
-      );
-    });
-  });
-});
+      it("throws an error if `query` is empty", () => {
+        expect(() =>
+          dynamicBadge(
+            "version",
+            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+            ""
+          )
+        ).toThrow();
+      });
+    })
+  })
+})

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -62,5 +62,20 @@ describe("Dynamic data badges", () => {
         );
       });
     });
+
+    describe("required and optional input handling", () => {
+      const altText = "VS Code";
+      const label = "vscode";
+      const url =
+        "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json";
+      const query = '$.engines["vscode"]';
+
+      it("displays a badge correctly when accessing a property from a nested object", () => {
+        const expected =
+          "![VS Code](https://img.shields.io/badge/dynamic/json?label=vscode&query=%24.engines%5B%22vscode%22%5D&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)";
+
+        expect(dynamicBadge(label, url, query, "", altText)).toBe(expected);
+      });
+    });
   });
 });

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -1,0 +1,56 @@
+import { dynamicBadge } from "@/core/dynamicData";
+
+describe("#dynamicBadge", () => {
+  describe("Url, label, and query", () => {
+    it("displays a badge with a given label, URL and query", () => {
+      expect(
+        dynamicBadge(
+          "version",
+          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+          "version"
+        )
+      ).toBe(
+        "![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
+      );
+    });
+
+    it("throws an error if `label` is empty", () => {
+      expect(() =>
+        dynamicBadge(
+          "",
+          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+          "version"
+        )
+      ).toThrow();
+    });
+
+    it("throws an error if `url` is empty", () => {
+      expect(() => dynamicBadge("version", "", "version")).toThrow();
+    });
+
+    it("throws an error if `query` is empty", () => {
+      expect(() =>
+        dynamicBadge(
+          "version",
+          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+          ""
+        )
+      ).toThrow();
+    });
+
+    it("displays a badge pointing to an external link", () => {
+      const linkTarget = "https://example.com";
+
+      expect(
+        dynamicBadge(
+          "version",
+          "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
+          "version",
+          linkTarget
+        )
+      ).toBe(
+        "[![](https://img.shields.io/badge/dynamic/json?label=version&query=version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
+      );
+    });
+  });
+});

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -2,60 +2,69 @@ import { dynamicBadge } from "@/core/dynamicData";
 
 describe("Dynamic data badges", () => {
   describe("#dynamicBadge", () => {
-    describe("required inputs set", () => {
+    describe("required input handling", () => {
+      const label = "version"
+      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
+      const query = "$.version"
+
       it("displays a badge correctly when label, URL, query are set", () => {
-        expect(
-          dynamicBadge(
-            "version",
-            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-            "$.version"
-          )
-        ).toBe(
-          "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
+        const expected = "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
+        
+        expect(dynamicBadge(label,url,query)).toBe(
+          expected
         );
       });
 
-      describe("optional inputs are set", () => {
-        it("displays a badge pointing to an external link", () => {
-          const linkTarget = "https://example.com";
+      describe("validate missing inputs", () => {
+        it("throws an error when `label` is not set", () => {
+          expect(() =>
+            dynamicBadge("", url,  query)
+          ).toThrow();
 
-          expect(
+          expect(() =>
+            dynamicBadge(undefined, url,  query)
+          ).toThrow();
+
+          expect(() =>
+            dynamicBadge(null, url,  query)
+          ).toThrow();
+        });
+  
+        it("throws an error when `url` is not set", () => {
+          expect(() => dynamicBadge(label, "", query)).toThrow();
+        });
+  
+        it("throws an error when `query` is not set", () => {
+          expect(() =>
             dynamicBadge(
-              "version",
-              "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-              "$.version",
-              linkTarget
+              label,
+              url,
+              ""
             )
-          ).toBe(
-            "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
-          );
+          ).toThrow();
         });
       });
     });
 
-    describe("validate when required inputs are not set", () => {
-      it("throws an error if `label` is empty", () => {
-        expect(() =>
+    describe("optional input handling", () => {
+      const label = "version"
+      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
+      const query = "$.version"
+      
+      it("displays a badge pointing to an external link when a link is given", () => {
+        const linkTarget = "https://example.com";
+        const expected = "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
+        
+        expect(
           dynamicBadge(
-            "",
-            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-            "version"
+            label,
+            url,
+            query,
+            linkTarget
           )
-        ).toThrow();
-      });
-
-      it("throws an error if `url` is empty", () => {
-        expect(() => dynamicBadge("version", "", "version")).toThrow();
-      });
-
-      it("throws an error if `query` is empty", () => {
-        expect(() =>
-          dynamicBadge(
-            "version",
-            "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json",
-            ""
-          )
-        ).toThrow();
+        ).toBe(
+          expected
+        );
       });
     });
   });

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -36,12 +36,30 @@ describe("Dynamic data badges", () => {
         "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json";
       const query = "$.version";
 
-      it("displays a badge pointing to an external link when a link is given", () => {
-        const linkTarget = "https://example.com";
+      const linkTarget = "https://example.com";
+      const altText = "My alt text";
+
+      it("returns a that uses an external link when one is given", () => {
         const expected =
           "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)";
 
         expect(dynamicBadge(label, url, query, linkTarget)).toBe(expected);
+      });
+
+      it("returns a badge with image alt text when alt text is given", () => {
+        const expected =
+          "![My alt text](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)";
+
+        expect(dynamicBadge(label, url, query, "", altText)).toBe(expected);
+      });
+
+      it("returns a badge with alt text and external link when both are given", () => {
+        const expected =
+          "[![My alt text](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)";
+
+        expect(dynamicBadge(label, url, query, linkTarget, altText)).toBe(
+          expected
+        );
       });
     });
   });

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -3,68 +3,49 @@ import { dynamicBadge } from "@/core/dynamicData";
 describe("Dynamic data badges", () => {
   describe("#dynamicBadge", () => {
     describe("required input handling", () => {
-      const label = "version"
-      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
-      const query = "$.version"
+      const label = "version";
+      const url =
+        "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json";
+      const query = "$.version";
 
       it("displays a badge correctly when label, URL, query are set", () => {
-        const expected = "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)"
-        
-        expect(dynamicBadge(label,url,query)).toBe(
-          expected
-        );
+        const expected =
+          "![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)";
+
+        expect(dynamicBadge(label, url, query)).toBe(expected);
       });
 
       describe("validate missing inputs", () => {
         it("throws an error when `label` is not set", () => {
-          expect(() =>
-            dynamicBadge("", url,  query)
-          ).toThrow();
+          expect(() => dynamicBadge("", url, query)).toThrow();
 
-          expect(() =>
-            dynamicBadge(undefined, url,  query)
-          ).toThrow();
+          expect(() => dynamicBadge(undefined, url, query)).toThrow();
 
-          expect(() =>
-            dynamicBadge(null, url,  query)
-          ).toThrow();
+          expect(() => dynamicBadge(null, url, query)).toThrow();
         });
-  
+
         it("throws an error when `url` is not set", () => {
           expect(() => dynamicBadge(label, "", query)).toThrow();
         });
-  
+
         it("throws an error when `query` is not set", () => {
-          expect(() =>
-            dynamicBadge(
-              label,
-              url,
-              ""
-            )
-          ).toThrow();
+          expect(() => dynamicBadge(label, url, "")).toThrow();
         });
       });
     });
 
     describe("optional input handling", () => {
-      const label = "version"
-      const url = "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json"
-      const query = "$.version"
-      
+      const label = "version";
+      const url =
+        "https://raw.githubusercontent.com/MichaelCurrin/auto-commit-msg/master/package.json";
+      const query = "$.version";
+
       it("displays a badge pointing to an external link when a link is given", () => {
         const linkTarget = "https://example.com";
-        const expected = "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
-        
-        expect(
-          dynamicBadge(
-            label,
-            url,
-            query,
-            linkTarget
-          )
-        ).toBe(
-          expected
-        );
+        const expected =
+          "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)";
+
+        expect(dynamicBadge(label, url, query, linkTarget)).toBe(expected);
       });
     });
   });

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -29,9 +29,9 @@ describe("Dynamic data badges", () => {
           ).toBe(
             "[![version](https://img.shields.io/badge/dynamic/json?label=version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FMichaelCurrin%2Fauto-commit-msg%2Fmaster%2Fpackage.json)](https://example.com)"
           );
-        })
-      })
-    })
+        });
+      });
+    });
 
     describe("validate when required inputs are not set", () => {
       it("throws an error if `label` is empty", () => {
@@ -57,6 +57,6 @@ describe("Dynamic data badges", () => {
           )
         ).toThrow();
       });
-    })
-  })
-})
+    });
+  });
+});

--- a/tests/unit/core/dynamicBadge.spec.ts
+++ b/tests/unit/core/dynamicBadge.spec.ts
@@ -18,10 +18,6 @@ describe("Dynamic data badges", () => {
       describe("validate missing inputs", () => {
         it("throws an error when `label` is not set", () => {
           expect(() => dynamicBadge("", url, query)).toThrow();
-
-          expect(() => dynamicBadge(undefined, url, query)).toThrow();
-
-          expect(() => dynamicBadge(null, url, query)).toThrow();
         });
 
         it("throws an error when `url` is not set", () => {


### PR DESCRIPTION
Addresses #122 

We do not encode the query parameters prior building the URL,
because the `buildUrl` function already encodes them.

This adds the minimal feature of Dynamic Badges, colour support and other features are pending. 