### PR TITLE
Add a store to persist repo data

### DIFF
--- a/src/core/packages.ts
+++ b/src/core/packages.ts
@@ -4,7 +4,7 @@
 import {
   GO_MODULE_SHIELD,
   NODE_VERSION_BADGE,
-  STATIC_DEPENDENCY
+  STATIC_DEPENDENCY,
 } from "@/constants/badgeValues";
 import { REGISTRY, SHIELDS_API } from "@/constants/urls";
 import { buildUrl } from "./badges";
@@ -14,7 +14,7 @@ import { Repo } from "./Repo";
 import {
   ENVIRONMENT,
   logoQueryParams,
-  nodePkgJsonShieldUrl
+  nodePkgJsonShieldUrl,
 } from "./shieldsApi";
 import { TLogoAppearance } from "./shieldsApi.d";
 

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,0 +1,54 @@
+import { reactive } from "vue";
+
+/**
+ * Global store.
+ *
+ * The store will keep track of the values
+ * that the user enters on the existing
+ * forms, and thus, can be reused across
+ * several forms. For example, the GitHub
+ * username and the repository name can be
+ * reused when creating a package badge or
+ * a repository badge.
+ *
+ */
+const store = {
+  debug: true,
+
+  state: reactive({
+    repositoryName: "badge-generator",
+    ghUsername: "MichaelCurrin",
+  }),
+
+  /**
+   * Overwrites the current repository name
+   * with the passed value.
+   *
+   * @param newValue a string that represents
+   * the new repository name
+   */
+  setRepositoryName(newValue: string) {
+    if (this.debug) {
+      console.log("Setting the repository name.");
+    }
+
+    this.state.repositoryName = newValue;
+  },
+
+  /**
+   * Overwrites the current GitHub username
+   * with the passed value.
+   *
+   * @param newValue a string that represents
+   * the new repository name
+   */
+  setGitHubUsername(newValue: string) {
+    if (this.debug) {
+      console.log("Setting the GitHub Username");
+    }
+
+    this.state.ghUsername = newValue;
+  },
+};
+
+export default store;

--- a/src/views/PackageBadges.vue
+++ b/src/views/PackageBadges.vue
@@ -192,6 +192,7 @@ import { REGISTRY, RegistryKeys } from "@/constants/urls";
 import { dependency, nodeVersionBadge } from "@/core/packages";
 import { Repo } from "@/core/Repo";
 import { ENVIRONMENT, EnvironmentKeys } from "@/core/shieldsApi";
+import store from "@/core/store";
 
 const NOTE = `
 - For NPM, the badge is dynamic - whatever package name you set, the version of that package in your repo will be used, without having to update the badge code. The Environent setting is for prod vs dev dependencies.
@@ -215,8 +216,8 @@ export default defineComponent({
       prodOption: ENVIRONMENT[ENVIRONMENT.Prod],
       envType: ENVIRONMENT[ENVIRONMENT.Prod],
 
-      username: "MichaelCurrin",
-      repoName: "badge-generator",
+      username: store.state.ghUsername,
+      repoName: store.state.repositoryName,
 
       badgeColor: COLOR_PRESETS.Default,
       logo: "",
@@ -252,6 +253,9 @@ export default defineComponent({
       const dependencyBadge = registry
         ? dependency(this.pkgName, registry, logoAppearance, this.badgeColor)
         : "";
+
+      store.setGitHubUsername(this.username);
+      store.setRepositoryName(this.repoName);
 
       const repo = new Repo(this.username, this.repoName);
       const envKey = this.envType as EnvironmentKeys,

--- a/src/views/RepoBadges.vue
+++ b/src/views/RepoBadges.vue
@@ -128,6 +128,7 @@ import TextInput from "@/components/TextInput.vue";
 import { Repo } from "@/core/Repo";
 import { TagTypes } from "@/core/Repo.d";
 import { statusBadge } from "@/core/ghActions";
+import store from "@/core/store";
 
 const note = `
 - Where to put the repo metadata badges.
@@ -154,8 +155,8 @@ export default defineComponent({
   },
   data() {
     return {
-      username: "MichaelCurrin",
-      repoName: "badge-generator",
+      username: store.state.ghUsername,
+      repoName: store.state.repositoryName,
       licenseType: "MIT",
 
       useThisTemplate: false,
@@ -184,6 +185,9 @@ export default defineComponent({
         workflowName: this.workflowName,
         badgeColor: this.badgeColor,
       });
+
+      store.setGitHubUsername(this.username);
+      store.setRepositoryName(this.repoName);
 
       const repo = new Repo(
         this.username,


### PR DESCRIPTION
Addresses issue #117.

The global store will maintain repository data previously entered, so we can reuse it in other parts of the site.

This may be expanded to persist other values.